### PR TITLE
Fix UI bugs and minor improvements 

### DIFF
--- a/server/auth/pkg/api/groups.go
+++ b/server/auth/pkg/api/groups.go
@@ -88,6 +88,11 @@ func (a *Auth) DeleteGroup(c *gin.Context) {
 
 	groupName := c.Param("groupname")
 
+	if (groupName == "admin") || (groupName == "public") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "The public and admin groups cannot be deleted."})
+		return
+	}
+
 	if roleValid := a.validateAdminOrPrivilegedMember(userInfo.Role, userInfo.Username, groupName); !roleValid {
 		c.JSON(http.StatusUnauthorized, gin.H{"error": ErrUnauthorized.Error()})
 		return

--- a/server/core/pkg/api/dataset_perms.go
+++ b/server/core/pkg/api/dataset_perms.go
@@ -70,6 +70,12 @@ func UpdateGroupDatasetPerms(c *gin.Context) {
 		return
 	}
 
+	// You can't change the admin group permissions to read-only
+	if groupName == "admin" && accessLevel == "r" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "The admin group permissions cannot be set to read-only."})
+		return
+	}
+
 	updateDatasetPerms(c, namespace, datasetName, groupName, accessLevel)
 }
 

--- a/server/ui/ui/src/components/modal/Modal.scss
+++ b/server/ui/ui/src/components/modal/Modal.scss
@@ -88,6 +88,9 @@
     &--medium {
       @include modal(440px, 735px);
     }
+    &--flex {
+      @include modal(280px, 735px);
+    }
 
     &--small {
       padding: 0;

--- a/server/ui/ui/src/pages/account/modal/PasswordModal.tsx
+++ b/server/ui/ui/src/pages/account/modal/PasswordModal.tsx
@@ -80,7 +80,7 @@ const PasswordModal: FC<Props> = (
       return response.json();
       })
     .then((data) => {
-      if (data.error) {
+      if (data && data.error) {
         setError(data.error)
         setTimeout(() => {
           setError(null)

--- a/server/ui/ui/src/pages/dataset/filebrowser/details/Details.scss
+++ b/server/ui/ui/src/pages/dataset/filebrowser/details/Details.scss
@@ -89,7 +89,7 @@
     &__table{
       height: 240px;
       border: 1px solid #979797;
-      overflow: scroll;
+      overflow: auto;
     }
     &__header {
       display: flex;
@@ -108,10 +108,27 @@
       justify-content: space-between;
       height: 24px;
       border-bottom: 1px solid #979797;
+      svg {
+        visibility: hidden;
+        position: absolute;
+        right: 2px;
+        bottom: 5px;
+      }
       span {
+        cursor: pointer;
         line-height: 24px;
         padding-left: 10px;
         width: 50%;
+        padding-right: 5px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        position: relative;
+        &:hover {
+          padding-right: 18px;
+          svg {
+            visibility: initial;
+          }
+        }
       }
     }
   }

--- a/server/ui/ui/src/pages/dataset/filebrowser/details/Details.tsx
+++ b/server/ui/ui/src/pages/dataset/filebrowser/details/Details.tsx
@@ -1,10 +1,12 @@
 // vendor
 import React, { FC, useState, useRef } from 'react';
 import Moment from 'moment';
+import ReactTooltip from 'react-tooltip';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { InputText } from 'Components/form/text/index';
 import { faCopy } from '@fortawesome/free-solid-svg-icons';
 import { ReactComponent as CloseIcon } from 'Images/icons/icon-close.svg';
+
 
 // css
 import './Details.scss';
@@ -39,6 +41,8 @@ const Details:FC<Props> = ({
 
   const [eTagCopied, setETagCopied] = useState(false);
   const [URICopied, setURICopied] = useState(false);
+  const [copiedEntry, setCopiedEntry] = useState(null);
+  const [copiedValue, setCopiedValue] = useState(null);
   const [metaSearch, setMetaSearch] = useState('');
   const inputRef = useRef(null);
 
@@ -217,13 +221,47 @@ const Details:FC<Props> = ({
                 </div>
                 <div className="Details__meta__contents">
                   {
-                    Object.keys(filteredMeta).map((entry) => (
+                    Object.keys(filteredMeta).map((entry, index) => (
                     <div className="Details__meta__entry" key={entry}>
-                      <span>
+                      <span
+                        key={copiedEntry === index ? `${entry}--hidden` : entry}
+                        data-tip={copiedEntry === index ? 'Copied to clipboard' : entry.length > 15 ? entry : ''}
+                        role="presentation"
+                        onClick={() =>{
+                          copyToClipboard(entry);
+                          setCopiedEntry(index);
+                          setTimeout(() => {
+                            setCopiedEntry(null)
+                          }, 3000);
+                        }}
+                      >
                         {entry}
+                       <FontAwesomeIcon icon={faCopy} color={primaryHash} />
+
+                        <ReactTooltip
+                          place="bottom"
+                          effect="solid"
+                        />
                       </span>
-                      <span>
+                      <span
+                        key={copiedValue === index ? `${data.Metadata[entry]}--hidden` : data.Metadata[entry]}
+                        role="presentation"
+                        onClick={() =>{
+                          copyToClipboard(data.Metadata[entry])
+                          setCopiedValue(index);
+                          setTimeout(() => {
+                            setCopiedValue(null)
+                          }, 3000);
+                        }}
+                        data-tip={copiedValue === index ? 'Copied to clipboard' : data.Metadata[entry].length > 15 ? data.Metadata[entry] : ''}
+                      >
                         {data.Metadata[entry]}
+                       <FontAwesomeIcon icon={faCopy} color={primaryHash} />
+
+                        <ReactTooltip
+                          place="bottom"
+                          effect="solid"
+                        />
                       </span>
                     </div>
                     ))

--- a/server/ui/ui/src/pages/dataset/filebrowser/file/File.tsx
+++ b/server/ui/ui/src/pages/dataset/filebrowser/file/File.tsx
@@ -33,6 +33,7 @@ interface Props {
   setIsLocked: (locked: boolean) => void;
   namespace: string;
   searchMode: boolean;
+  setErrorModal: any;
 }
 
 
@@ -51,6 +52,7 @@ const File:FC<Props> = ({
   setIsLocked,
   namespace,
   searchMode,
+  setErrorModal,
 }: Props) => {
 
   const [renameMode, setRenameMode] = useState(false);
@@ -115,8 +117,17 @@ const File:FC<Props> = ({
               setIsLocked(false)
               refetchS3();
               removeFiles([file.Key]);
-            });
-          });
+            })
+          })
+          .catch((error: any) => {
+            setIsLocked(false);
+            setRenameMode(false);
+            setErrorModal({
+              visible: true,
+              action: 'renaming file',
+              error: error.message,
+            })
+          })
     }
   }
 
@@ -193,6 +204,7 @@ const File:FC<Props> = ({
           removeFiles={removeFiles}
           allowRename={(editedFileName.length > 0)}
           searchMode={searchMode}
+          setErrorModal={setErrorModal}
         />
       </div>
     </div>

--- a/server/ui/ui/src/pages/dataset/filebrowser/folder/Folder.tsx
+++ b/server/ui/ui/src/pages/dataset/filebrowser/folder/Folder.tsx
@@ -86,6 +86,7 @@ interface Props {
   setSearchFolderExpanded: any;
   effectiveFolderList: any;
   isLocked: boolean;
+  setErrorModal: any;
 }
 
 export const Folder:FC<Props> = ({
@@ -123,6 +124,7 @@ export const Folder:FC<Props> = ({
   setSearchFolderExpanded,
   effectiveFolderList,
   isLocked,
+  setErrorModal,
 }: Props) => {
 
   const splitName = folder.Prefix.split('/');
@@ -245,7 +247,15 @@ export const Folder:FC<Props> = ({
                 removeFiles([item.file.Key]);
                 setIsLocked(false);
               });
-            });
+            })
+            .catch((error: any) => {
+              setIsLocked(false);
+              setErrorModal({
+                visible: true,
+                action: 'moving file(s)',
+                error: error.message,
+              })
+            })
         }
         if (item.folder
           && item.parentFolder !== folder.Prefix
@@ -472,6 +482,7 @@ export const Folder:FC<Props> = ({
               allowRename={(editedFolderName.length > 0)}
               setNewFolderVisible={setNewFolderVisible}
               searchMode={searchMode}
+              setErrorModal={setErrorModal}
             />
           </div>
           {
@@ -590,6 +601,7 @@ export const Folder:FC<Props> = ({
                   searchMode={searchMode}
                   setSearchFolderExpanded={setSearchFolderExpanded}
                   effectiveFolderList={effectiveFolderList}
+                  setErrorModal={setErrorModal}
                 />
               )
               })
@@ -649,6 +661,7 @@ export const Folder:FC<Props> = ({
                   setIsLocked={setIsLocked}
                   namespace={namespace}
                   searchMode={searchMode}
+                  setErrorModal={setErrorModal}
                 />
               )
               })

--- a/server/ui/ui/src/pages/dataset/section/DatasetSection.tsx
+++ b/server/ui/ui/src/pages/dataset/section/DatasetSection.tsx
@@ -60,11 +60,13 @@ const DatasetSection: FC<Props> = ({
               list={users}
               sectionType="user"
               headerText="Users"
+              owner={dataset.owner.username}
             />
             <PermissionsSection
               list={groups}
               sectionType="group"
               headerText="Groups"
+              owner={dataset.owner.username}
             />
           </div>
         </SectionCard>

--- a/server/ui/ui/src/pages/dataset/section/DatasetSectionTypes.ts
+++ b/server/ui/ui/src/pages/dataset/section/DatasetSectionTypes.ts
@@ -33,6 +33,7 @@ export interface Dataset {
   sync_type: string;
   sync_policy: string;
   sync_enabled: boolean;
+  owner: any;
 }
 
 

--- a/server/ui/ui/src/pages/dataset/section/permissions/PermissionsSection.tsx
+++ b/server/ui/ui/src/pages/dataset/section/permissions/PermissionsSection.tsx
@@ -23,10 +23,11 @@ interface Props {
   list: Array<Permission>;
   sectionType: string;
   headerText: string;
+  owner: string;
 }
 
 
-const PermissionsSection: FC<Props> = ({ list, sectionType, headerText }: Props) => {
+const PermissionsSection: FC<Props> = ({ list, sectionType, headerText, owner }: Props) => {
 
   // context
   const { user } = useContext(AppContext);
@@ -79,6 +80,7 @@ const PermissionsSection: FC<Props> = ({ list, sectionType, headerText }: Props)
                   key={item.group.group_name}
                   item={item}
                   sectionType={sectionType}
+                  owner={owner}
                 />
               )
             })

--- a/server/ui/ui/src/pages/dataset/section/permissions/item/PermissionsItem.scss
+++ b/server/ui/ui/src/pages/dataset/section/permissions/item/PermissionsItem.scss
@@ -10,6 +10,9 @@
 
   border-bottom: 1px solid $romanSilver;
 
+  &__error {
+    width: 300px;
+  }
   &__name {
     min-width: 20em;
     overflow: hidden;

--- a/server/ui/ui/src/pages/dataset/section/shared/add/AddSection.tsx
+++ b/server/ui/ui/src/pages/dataset/section/shared/add/AddSection.tsx
@@ -82,12 +82,26 @@ const AddSection: FC<Props> = ({ sectionType }:Props) => {
         if (permissions.name === 'Read Only') {
           permName = 'r';
         }
-        put(`namespace/${namespace}/dataset/${datasetName}/${sectionType}/${name}/access/${permName}`).then((response) => {
-          send('REFETCH');
-          setPermissions({name: 'r'});
-          setName('');
-          setErrorMessage('');
-        }).catch((error) => {
+        put(`namespace/${namespace}/dataset/${datasetName}/${sectionType}/${name}/access/${permName}`)
+        .then((response) => {
+          if (response.ok) {
+            send('REFETCH');
+            setPermissions({name: 'r'});
+            setName('');
+            setErrorMessage('');
+            return;
+          }
+          return response.json()
+        })
+        .then((data: any) => {
+          if(data && data.error) {
+            setErrorMessage(data.error);
+            setTimeout(() => {
+              setErrorMessage('');
+            }, 5000);
+          }
+        })
+        .catch((error) => {
           const newErrorMessage = error.toString ? error.toString() : error;
           setErrorMessage(newErrorMessage);
         })
@@ -151,7 +165,7 @@ const AddSection: FC<Props> = ({ sectionType }:Props) => {
   return (
     <>
       <div className="AddSection">
-        <div>
+        <div className="relative">
             <UserInput
               inputRef={inputRef}
               permissionType={sectionType}

--- a/server/ui/ui/src/pages/dataset/section/shared/add/input/UserInput.scss
+++ b/server/ui/ui/src/pages/dataset/section/shared/add/input/UserInput.scss
@@ -3,6 +3,7 @@
   align-items: flex-end;
   align-content: flex-end;
   padding: 10px;
+  position: relative;
   .InputText__label {
     text-transform: none !important;
   }

--- a/server/ui/ui/src/pages/groups/group/section/GroupSection.tsx
+++ b/server/ui/ui/src/pages/groups/group/section/GroupSection.tsx
@@ -40,7 +40,7 @@ const GroupSection: FC<Props> = ({ group }: Props) => {
           For example, if a group is given read/write access to a dataset, all users in the group will be able to read and write data.
         </p>
         <p>
-          Users with the &quot;admin&quot; role can add and remove users from any group. Users with the &quot;privileged&quot; role can add and remove users from the group only if they are a member of the group.
+          To manage groups, you must have the &quot;admin&quot; or &quot;privileged&quot; role.
         </p>
       </div>
       <div>

--- a/server/ui/ui/src/pages/groups/group/section/add/AddUser.tsx
+++ b/server/ui/ui/src/pages/groups/group/section/add/AddUser.tsx
@@ -35,8 +35,7 @@ const AddUser: FC = () => {
   const [buttonDisabled, setButtonDisabled] = useState(false);
   // vars
   const usersGroups = user.profile.groups.split(',');
-  const canMemberEdit = (user.profile.role === 'admin') || ((usersGroups.indexOf(groupname) > -1 )
-    && (user.profile.role === 'admin'))
+  const canMemberEdit = (user.profile.role === 'admin') ||  (user.profile.role === 'privileged')
     ? true
     : false;
   const editDisabled = (username === null) || (username === '') || !canMemberEdit;
@@ -56,7 +55,7 @@ const AddUser: FC = () => {
     ).then((response) => {
       return response.json();
     }).then((data) => {
-      if (data.error) {
+      if (data && data.error) {
         setErrorMessage(data.error);
         return;
       }

--- a/server/ui/ui/src/pages/groups/groups/section/create/CreateGroupModal.tsx
+++ b/server/ui/ui/src/pages/groups/groups/section/create/CreateGroupModal.tsx
@@ -57,7 +57,7 @@ const CreateGroup: FC<Props> = ({
     post('group/', body, true).then((response) => {
       return response.json();
     }).then((data) => {
-      if (data.error) {
+      if (data && data.error) {
         setErrorMessage(data.error);
         return;
       }

--- a/server/ui/ui/src/pages/namespace/Namespace.tsx
+++ b/server/ui/ui/src/pages/namespace/Namespace.tsx
@@ -12,6 +12,7 @@ import {
   useLocation,
 } from "react-router-dom";
 import { useMachine } from '@xstate/react';
+import ReactTooltip from 'react-tooltip';
 // context
 import AppContext from 'Src/AppContext';
 // enivornment
@@ -212,10 +213,17 @@ const Namespace: FC<Props> = ({ setSyncValue }:Props) => {
             </p>
             <div
               className="Namespace__Delete--buttons relative"
+              data-tip="Only administrators can delete a namespace."
+              data-tip-disable={user.profile.role === 'admin'}
             >
               <WarningButton
                 click={() => setIsModalVisible(true)}
+                disabled={user.profile.role !== 'admin'}
                 text="Delete Namespace"
+              />
+              <ReactTooltip
+                place="bottom"
+                effect="solid"
               />
             </div>
           </div>

--- a/server/ui/ui/src/pages/tokens/section/PatSection.tsx
+++ b/server/ui/ui/src/pages/tokens/section/PatSection.tsx
@@ -44,7 +44,7 @@ const PatSection: FC = () => {
     get('pat/', true).then((response) => {
         return response.json();
       }).then((data) => {
-        if (data.error) {
+        if (data && data.error) {
           send('ERROR', { error: data.error })
           return;
         }

--- a/server/ui/ui/src/pages/tokens/section/list/create/CreatePatModal.tsx
+++ b/server/ui/ui/src/pages/tokens/section/list/create/CreatePatModal.tsx
@@ -63,7 +63,7 @@ const CreatePatModal: FC<Props> = ({
     post('pat', body, true).then((response) => {
       return response.json();
     }).then((data) => {
-      if (data.error) {
+      if (data && data.error) {
         setErrorMessage(data.error);
         return;
       }

--- a/server/ui/ui/src/shared/permission/PermissionDropdown.tsx
+++ b/server/ui/ui/src/shared/permission/PermissionDropdown.tsx
@@ -22,7 +22,7 @@ interface DropdownItem {
 interface Props {
   name: string;
   permission: DropdownItem;
-  updatePermissions: (permission: DropdownItem, name: string) => void;
+  updatePermissions: (permission: DropdownItem, name: string, errorCallback: () => void) => void;
 }
 
 
@@ -80,7 +80,12 @@ const PermissionDropdown: FC<Props> = ({
 
   useEffect(() => {
     if (permission.name !== state.selectedItem.name) {
-      updatePermissions(state.selectedItem, name);
+      updatePermissions(state.selectedItem, name, () => {
+        dispatch({
+          type: 'set',
+          payload: { selectedItem: permission }
+        });
+      });
     }
   }, [state.selectedItem, updatePermissions, name, permission]);
 

--- a/test/test_integration/test_auth.py
+++ b/test/test_integration/test_auth.py
@@ -68,6 +68,12 @@ class TestAuthService:
         assert public_group.name == "public"
         assert len(public_group.members) == 3, "Public group not correct, did you login with all 3 test accounts?"
 
+        with pytest.raises(hoss.HossException):
+            server.auth.delete_group("admin")
+
+        with pytest.raises(hoss.HossException):
+            server.auth.delete_group("public")
+
     def test_admin_can_remove_user_from_public(self, fixture_test_public_group):
         server = fixture_test_public_group
 


### PR DESCRIPTION
- Long metadata tags now `...` and have a tooltip to show the whole value. Clicking copies the value to the clipboard
- Resolved bug in minio where metadata was not updating properly switching from file to file
- Delete namespace is now disabled for non-admins (with a tooltip)
- Error handling added for all S3 commands, resolves issue with UI freezing up when you have read-only permissions
- Groups page bugs when you had the `privileged` role resolved
- Error handling added to the group and permission widgets
- Checks to ensure the system groups cannot be deleted added
- Check to ensure a user can't remove the creator of a dataset added

Signed-off-by: Dean Kleissas <dean@gigantum.com>