### PR TITLE
Handle error if metadata lookup fails

### DIFF
--- a/server/ui/ui/src/pages/dataset/filebrowser/FileBrowser.tsx
+++ b/server/ui/ui/src/pages/dataset/filebrowser/FileBrowser.tsx
@@ -777,10 +777,12 @@ const FileBrowser:FC<Props> = ({
         get(`search/namespace/${namespace}/dataset/${dataset}/metadata?objectKey=${encodeURIComponent(focusedFile.Key)}`)
         .then(res => res.json())
         .then(data => {
-          setFocusedFileData((prevData: any) => ({
-            ...prevData,
-            Metadata: data.metadata,
-          }))
+          if (data && data.metadata) {
+            setFocusedFileData((prevData: any) => ({
+              ...prevData,
+              Metadata: data.metadata,
+            }))
+          }
         })
       }
     } else if (focusedFile && focusedFileData) {


### PR DESCRIPTION
Small PR to fix an edge case bug. If a file was uploaded, and for some reason the metadata for that file was not written to the index (should not happen in production, but has been seen during testing when files are written during a misconfiguration), the UI would crash. This simple fix prevents that.

Signed-off-by: Dean Kleissas <dean@gigantum.com>