### PR TITLE
Fix race condition on focus file select in file browser

### DIFF
--- a/server/ui/ui/.eslintrc.json
+++ b/server/ui/ui/.eslintrc.json
@@ -16,7 +16,8 @@
   "rules": {
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "warn",
-    "react/prop-types": "off"
+    "react/prop-types": "off",
+    "react/jsx-key": "off"
   },
   "settings": {
     "react": {
@@ -57,7 +58,8 @@
          "ts": "never",
          "tsx": "never"
       }
-    ]
+    ],
+    "react/jsx-key": "warn"
   },
   "overrides": [
     {

--- a/server/ui/ui/src/pages/dataset/filebrowser/FileBrowser.tsx
+++ b/server/ui/ui/src/pages/dataset/filebrowser/FileBrowser.tsx
@@ -768,20 +768,34 @@ const FileBrowser:FC<Props> = ({
       })
       s3Client.send(command)
       .then((res: any) => {
-        setFocusedFileData((prevData: any) => ({
-          ...res,
-          Metadata: (prevData && prevData.Metadata && prevData.ETag === res.ETag) ? prevData.Metadata : res.Metadata
-        }));
+        setFocusedFileData((prevData: any) => {
+          if (prevData && !prevData.ETag) {
+            return {
+            ...res,
+            Metadata: prevData.Metadata,
+            }
+          }
+          return {
+            ...res,
+          }
+        });
       })
       if (!isMinio) {
         get(`search/namespace/${namespace}/dataset/${dataset}/metadata?objectKey=${encodeURIComponent(focusedFile.Key)}`)
         .then(res => res.json())
         .then(data => {
           if (data && data.metadata) {
-            setFocusedFileData((prevData: any) => ({
-              ...prevData,
-              Metadata: data.metadata,
-            }))
+            setFocusedFileData((prevData: any) => {
+              if (prevData && (prevData.ETag === focusedFile.ETag)) {
+                return {
+                  ...prevData,
+                  Metadata: data.metadata
+                }
+              }
+              return {
+                Metadata: data.metadata,
+              }
+            })
           }
         })
       }


### PR DESCRIPTION
This PR adds a small fix due to a race condition, where depending on your network speed to the server and S3, metadata may fail to load properly in the side panel when a file is selected.